### PR TITLE
Eigenvector centrality by power iteration

### DIFF
--- a/jgrapht-core/src/main/java/org/jgrapht/alg/scoring/EigenvectorCentrality.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/scoring/EigenvectorCentrality.java
@@ -1,0 +1,207 @@
+/*
+ * (C) Copyright 2020, by Sebastiano Vigna.
+ *
+ * JGraphT : a free Java graph-theory library
+ *
+ * See the CONTRIBUTORS.md file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the
+ * GNU Lesser General Public License v2.1 or later
+ * which is available at
+ * http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR LGPL-2.1-or-later
+ */
+package org.jgrapht.alg.scoring;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.jgrapht.Graph;
+import org.jgrapht.GraphIterables;
+import org.jgrapht.Graphs;
+import org.jgrapht.alg.interfaces.VertexScoringAlgorithm;
+
+/**
+ * Eigenvector-centrality implementation.
+ *
+ * <p>
+ * Eigenvector centrality, introduced in 1895 by Edmund Landau for chess tournaments, associates
+ * with a (weighted) graph the left dominant eigenvector of its adjacency matrix. More information
+ * can be found on <a href="https://en.wikipedia.org/wiki/Eigenvector_centrality">wikipedia</a>.
+ * </p>
+ *
+ * <p>
+ * This is a simple iterative implementation of the
+ * <a href="https://en.wikipedia.org/wiki/Power_iteration">power method</a> which stops after a
+ * given number of iterations or if centrality values between two iterations do not change more than
+ * a predefined value (technically, we stop when the &#x2113;<sub>2</sub> norm of the difference
+ * between the current estimate and the next one drops below a given threshold). Correspondingly,
+ * the result will be &#x2113;<sub>2</sub>-normalized.
+ * </p>
+ *
+ * <p>
+ * Each iteration of the algorithm runs in linear time O(n+m) when n is the number of nodes and m
+ * the number of edges of the graph. The maximum number of iterations can be adjusted by the caller.
+ * The default value is {@link EigenvectorCentrality#MAX_ITERATIONS_DEFAULT}. Also in case of
+ * weighted graphs, negative weights are not expected.
+ * </p>
+ *
+ * @param <V> the graph vertex type
+ * @param <E> the graph edge type
+ *
+ * @author Sebastiano Vigna
+ */
+public final class EigenvectorCentrality<V, E>
+    implements
+    VertexScoringAlgorithm<V, Double>
+{
+    /**
+     * Default number of maximum iterations.
+     */
+    public static final int MAX_ITERATIONS_DEFAULT = 100;
+
+    /**
+	 * Default value for the tolerance. The calculation will stop if the &#x2113;<sub>2</sub> norm of
+	 * the difference of centrality values between iterations changes less than this value.
+	 */
+    public static final double TOLERANCE_DEFAULT = 0.0001;
+
+    private final Graph<V, E> g;
+    private Map<V, Double> scores;
+
+    /**
+	 * Create and execute an instance of EigenvectorCentrality
+	 *
+	 * @param g the input graph
+	 */
+    public EigenvectorCentrality(final Graph<V, E> g)
+    {
+        this(
+				g, MAX_ITERATIONS_DEFAULT, TOLERANCE_DEFAULT);
+    }
+
+    /**
+	 * Create and execute an instance of EigenvectorCentrality
+	 *
+	 * @param g the input graph
+	 * @param maxIterations the maximum number of iterations to perform
+	 */
+    public EigenvectorCentrality(
+			final Graph<V, E> g, final int maxIterations)
+    {
+		this(g, maxIterations, TOLERANCE_DEFAULT);
+    }
+
+    /**
+	 * Create and execute an instance of EigenvectorCentrality.
+	 *
+	 * @param g the input graph
+	 * @param maxIterations the maximum number of iterations to perform
+	 * @param tolerance calculation will stop if the &#x2113;<sub>2</sub> norm of the difference of
+	 *            centrality values between iterations changes less than this value
+	 */
+    public EigenvectorCentrality(
+			final Graph<V, E> g, final int maxIterations, final double tolerance)
+    {
+        this.g = g;
+        this.scores = new HashMap<>();
+
+		validate(maxIterations, tolerance);
+		run(maxIterations, tolerance);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Map<V, Double> getScores()
+    {
+        return Collections.unmodifiableMap(scores);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Double getVertexScore(final V v)
+    {
+        if (!g.containsVertex(v)) {
+            throw new IllegalArgumentException("Cannot return score of unknown vertex");
+        }
+        return scores.get(v);
+    }
+
+    /* Checks for the valid values of the parameters */
+	private void validate(final int maxIterations, final double tolerance)
+    {
+        if (maxIterations <= 0) {
+            throw new IllegalArgumentException("Maximum iterations must be positive");
+        }
+
+        if (tolerance <= 0.0) {
+            throw new IllegalArgumentException("Tolerance not valid, must be positive");
+        }
+    }
+
+    private void run(
+			int maxIterations,
+        final double tolerance)
+    {
+        // initialization
+        final int totalVertices = g.vertexSet().size();
+        final GraphIterables<V, E> iterables = g.iterables();
+
+		final double initScore = Math.sqrt(1.0d / totalVertices);
+        for (final V v : iterables.vertices()) {
+            scores.put(v, initScore);
+        }
+
+		// run the power method
+        Map<V, Double> nextScores = new HashMap<>();
+		double l2Norm = tolerance;
+
+		while (maxIterations > 0 && l2Norm >= tolerance) {
+            // compute next iteration scores
+			double sumOfSquares = 0d;
+			for (final V v : iterables.vertices()) {
+				double vNewValue = 0d;
+
+                for (final E e : iterables.incomingEdgesOf(v)) {
+                    final V w = Graphs.getOppositeVertex(g, e, v);
+					vNewValue += scores.get(w) * g.getEdgeWeight(e);
+                }
+
+				sumOfSquares += vNewValue * vNewValue;
+                nextScores.put(v, vNewValue);
+            }
+
+			final double l2NormFactor = 1 / Math.sqrt(sumOfSquares);
+
+			double sumOfDiffs2 = 0;
+			// Normalize and evaluate norm
+			for (final V v : iterables.vertices()) {
+				final double score = nextScores.get(v) * l2NormFactor;
+				nextScores.put(v, score);
+				final double d = scores.get(v) - score;
+				sumOfDiffs2 += d * d;
+			}
+
+            // swap scores
+            final Map<V, Double> tmp = scores;
+            scores = nextScores;
+            nextScores = tmp;
+
+			l2Norm = Math.sqrt(sumOfDiffs2);
+
+            // progress
+            maxIterations--;
+        }
+
+    }
+
+}

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/scoring/EigenvectorCentrality.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/scoring/EigenvectorCentrality.java
@@ -66,53 +66,51 @@ public final class EigenvectorCentrality<V, E>
     public static final int MAX_ITERATIONS_DEFAULT = 100;
 
     /**
-	 * Default value for the tolerance. The calculation will stop if the &#x2113;<sub>2</sub> norm of
-	 * the difference of centrality values between iterations changes less than this value.
-	 */
+     * Default value for the tolerance. The calculation will stop if the &#x2113;<sub>2</sub> norm
+     * of the difference of centrality values between iterations changes less than this value.
+     */
     public static final double TOLERANCE_DEFAULT = 0.0001;
 
     private final Graph<V, E> g;
     private Map<V, Double> scores;
 
     /**
-	 * Create and execute an instance of EigenvectorCentrality
-	 *
-	 * @param g the input graph
-	 */
+     * Create and execute an instance of EigenvectorCentrality
+     *
+     * @param g the input graph
+     */
     public EigenvectorCentrality(final Graph<V, E> g)
     {
-        this(
-				g, MAX_ITERATIONS_DEFAULT, TOLERANCE_DEFAULT);
+        this(g, MAX_ITERATIONS_DEFAULT, TOLERANCE_DEFAULT);
     }
 
     /**
-	 * Create and execute an instance of EigenvectorCentrality
-	 *
-	 * @param g the input graph
-	 * @param maxIterations the maximum number of iterations to perform
-	 */
-    public EigenvectorCentrality(
-			final Graph<V, E> g, final int maxIterations)
+     * Create and execute an instance of EigenvectorCentrality
+     *
+     * @param g the input graph
+     * @param maxIterations the maximum number of iterations to perform
+     */
+    public EigenvectorCentrality(final Graph<V, E> g, final int maxIterations)
     {
-		this(g, maxIterations, TOLERANCE_DEFAULT);
+        this(g, maxIterations, TOLERANCE_DEFAULT);
     }
 
     /**
-	 * Create and execute an instance of EigenvectorCentrality.
-	 *
-	 * @param g the input graph
-	 * @param maxIterations the maximum number of iterations to perform
-	 * @param tolerance calculation will stop if the &#x2113;<sub>2</sub> norm of the difference of
-	 *            centrality values between iterations changes less than this value
-	 */
+     * Create and execute an instance of EigenvectorCentrality.
+     *
+     * @param g the input graph
+     * @param maxIterations the maximum number of iterations to perform
+     * @param tolerance calculation will stop if the &#x2113;<sub>2</sub> norm of the difference of
+     *        centrality values between iterations changes less than this value
+     */
     public EigenvectorCentrality(
-			final Graph<V, E> g, final int maxIterations, final double tolerance)
+        final Graph<V, E> g, final int maxIterations, final double tolerance)
     {
         this.g = g;
         this.scores = new HashMap<>();
 
-		validate(maxIterations, tolerance);
-		run(maxIterations, tolerance);
+        validate(maxIterations, tolerance);
+        run(maxIterations, tolerance);
     }
 
     /**
@@ -137,7 +135,7 @@ public final class EigenvectorCentrality<V, E>
     }
 
     /* Checks for the valid values of the parameters */
-	private void validate(final int maxIterations, final double tolerance)
+    private void validate(final int maxIterations, final double tolerance)
     {
         if (maxIterations <= 0) {
             throw new IllegalArgumentException("Maximum iterations must be positive");
@@ -148,55 +146,53 @@ public final class EigenvectorCentrality<V, E>
         }
     }
 
-    private void run(
-			int maxIterations,
-        final double tolerance)
+    private void run(int maxIterations, final double tolerance)
     {
         // initialization
         final int totalVertices = g.vertexSet().size();
         final GraphIterables<V, E> iterables = g.iterables();
 
-		final double initScore = Math.sqrt(1.0d / totalVertices);
+        final double initScore = Math.sqrt(1.0d / totalVertices);
         for (final V v : iterables.vertices()) {
             scores.put(v, initScore);
         }
 
-		// run the power method
+        // run the power method
         Map<V, Double> nextScores = new HashMap<>();
-		double l2Norm = tolerance;
+        double l2Norm = tolerance;
 
-		while (maxIterations > 0 && l2Norm >= tolerance) {
+        while (maxIterations > 0 && l2Norm >= tolerance) {
             // compute next iteration scores
-			double sumOfSquares = 0d;
-			for (final V v : iterables.vertices()) {
-				double vNewValue = 0d;
+            double sumOfSquares = 0d;
+            for (final V v : iterables.vertices()) {
+                double vNewValue = 0d;
 
                 for (final E e : iterables.incomingEdgesOf(v)) {
                     final V w = Graphs.getOppositeVertex(g, e, v);
-					vNewValue += scores.get(w) * g.getEdgeWeight(e);
+                    vNewValue += scores.get(w) * g.getEdgeWeight(e);
                 }
 
-				sumOfSquares += vNewValue * vNewValue;
+                sumOfSquares += vNewValue * vNewValue;
                 nextScores.put(v, vNewValue);
             }
 
-			final double l2NormFactor = 1 / Math.sqrt(sumOfSquares);
+            final double l2NormFactor = 1 / Math.sqrt(sumOfSquares);
 
-			double sumOfDiffs2 = 0;
-			// Normalize and evaluate norm
-			for (final V v : iterables.vertices()) {
-				final double score = nextScores.get(v) * l2NormFactor;
-				nextScores.put(v, score);
-				final double d = scores.get(v) - score;
-				sumOfDiffs2 += d * d;
-			}
+            double sumOfDiffs2 = 0;
+            // Normalize and evaluate norm
+            for (final V v : iterables.vertices()) {
+                final double score = nextScores.get(v) * l2NormFactor;
+                nextScores.put(v, score);
+                final double d = scores.get(v) - score;
+                sumOfDiffs2 += d * d;
+            }
 
             // swap scores
             final Map<V, Double> tmp = scores;
             scores = nextScores;
             nextScores = tmp;
 
-			l2Norm = Math.sqrt(sumOfDiffs2);
+            l2Norm = Math.sqrt(sumOfDiffs2);
 
             // progress
             maxIterations--;

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/scoring/EigenvectorCentralityTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/scoring/EigenvectorCentralityTest.java
@@ -36,23 +36,25 @@ public class EigenvectorCentralityTest
     @Test
     public void testGraph2Nodes()
     {
-        final DirectedPseudograph<String, DefaultEdge> g = new DirectedPseudograph<>(DefaultEdge.class);
+        final DirectedPseudograph<String, DefaultEdge> g =
+            new DirectedPseudograph<>(DefaultEdge.class);
 
         g.addVertex("1");
         g.addVertex("2");
         g.addEdge("1", "2");
         g.addEdge("2", "1");
 
-		final VertexScoringAlgorithm<String, Double> pr = new EigenvectorCentrality<>(g);
+        final VertexScoringAlgorithm<String, Double> pr = new EigenvectorCentrality<>(g);
 
-		assertEquals(pr.getVertexScore("1"), 1 / Math.sqrt(2), 0.0001);
-		assertEquals(pr.getVertexScore("2"), 1 / Math.sqrt(2), 0.0001);
+        assertEquals(pr.getVertexScore("1"), 1 / Math.sqrt(2), 0.0001);
+        assertEquals(pr.getVertexScore("2"), 1 / Math.sqrt(2), 0.0001);
     }
 
     @Test
     public void testGraph3Nodes()
     {
-        final DirectedPseudograph<String, DefaultEdge> g = new DirectedPseudograph<>(DefaultEdge.class);
+        final DirectedPseudograph<String, DefaultEdge> g =
+            new DirectedPseudograph<>(DefaultEdge.class);
 
         g.addVertex("1");
         g.addVertex("2");
@@ -61,17 +63,18 @@ public class EigenvectorCentralityTest
         g.addEdge("2", "3");
         g.addEdge("3", "1");
 
-		final VertexScoringAlgorithm<String, Double> pr = new EigenvectorCentrality<>(g);
+        final VertexScoringAlgorithm<String, Double> pr = new EigenvectorCentrality<>(g);
 
-		assertEquals(pr.getVertexScore("1"), 1 / Math.sqrt(3), 0.0001);
-		assertEquals(pr.getVertexScore("2"), 1 / Math.sqrt(3), 0.0001);
-		assertEquals(pr.getVertexScore("3"), 1 / Math.sqrt(3), 0.0001);
+        assertEquals(pr.getVertexScore("1"), 1 / Math.sqrt(3), 0.0001);
+        assertEquals(pr.getVertexScore("2"), 1 / Math.sqrt(3), 0.0001);
+        assertEquals(pr.getVertexScore("3"), 1 / Math.sqrt(3), 0.0001);
     }
 
     @Test
     public void testGraph1()
     {
-        final DirectedPseudograph<String, DefaultEdge> g = new DirectedPseudograph<>(DefaultEdge.class);
+        final DirectedPseudograph<String, DefaultEdge> g =
+            new DirectedPseudograph<>(DefaultEdge.class);
 
         g.addVertex("0");
         g.addVertex("1");
@@ -79,28 +82,27 @@ public class EigenvectorCentralityTest
         g.addVertex("3");
         g.addVertex("4");
 
-		g.addEdge("0", "1");
-		g.addEdge("0", "2");
-		g.addEdge("1", "3");
-		g.addEdge("1", "2");
-		g.addEdge("2", "1");
-		g.addEdge("2", "4");
-		g.addEdge("2", "3");
-		g.addEdge("3", "1");
-		g.addEdge("3", "2");
-		g.addEdge("3", "3");
-		g.addEdge("4", "2");
-		g.addEdge("4", "0");
+        g.addEdge("0", "1");
+        g.addEdge("0", "2");
+        g.addEdge("1", "3");
+        g.addEdge("1", "2");
+        g.addEdge("2", "1");
+        g.addEdge("2", "4");
+        g.addEdge("2", "3");
+        g.addEdge("3", "1");
+        g.addEdge("3", "2");
+        g.addEdge("3", "3");
+        g.addEdge("4", "2");
+        g.addEdge("4", "0");
 
-		final VertexScoringAlgorithm<String, Double> pr = new EigenvectorCentrality<>(g);
+        final VertexScoringAlgorithm<String, Double> pr = new EigenvectorCentrality<>(g);
 
-		assertEquals(pr.getVertexScore("0"), 0.08032022089204849, 0.001);
-		assertEquals(pr.getVertexScore("1"), 0.48765632797141506, 0.001);
-		assertEquals(pr.getVertexScore("2"), 0.5453987490787013, 0.001);
-		assertEquals(pr.getVertexScore("3"), 0.6437087676602127, 0.001);
-		assertEquals(pr.getVertexScore("4"), 0.20956906939251885, 0.001);
+        assertEquals(pr.getVertexScore("0"), 0.08032022089204849, 0.001);
+        assertEquals(pr.getVertexScore("1"), 0.48765632797141506, 0.001);
+        assertEquals(pr.getVertexScore("2"), 0.5453987490787013, 0.001);
+        assertEquals(pr.getVertexScore("3"), 0.6437087676602127, 0.001);
+        assertEquals(pr.getVertexScore("4"), 0.20956906939251885, 0.001);
     }
-
 
     @Test
     public void testWeightedGraph1()
@@ -111,33 +113,31 @@ public class EigenvectorCentralityTest
         g.addVertex("a");
         g.addVertex("b");
         g.addVertex("c");
-		g.addVertex("d");
+        g.addVertex("d");
 
-		g.setEdgeWeight(g.addEdge("a", "b"), 1. / 2);
-		g.setEdgeWeight(g.addEdge("a", "c"), 1. / 3);
-		g.setEdgeWeight(g.addEdge("b", "a"), 1);
-		g.setEdgeWeight(g.addEdge("b", "b"), 2);
-		g.setEdgeWeight(g.addEdge("b", "d"), 1. / 4);
-		g.setEdgeWeight(g.addEdge("c", "a"), 1);
-		g.setEdgeWeight(g.addEdge("c", "d"), 3);
-		g.setEdgeWeight(g.addEdge("d", "b"), 1. / 5);
-		g.setEdgeWeight(g.addEdge("d", "d"), 1);
+        g.setEdgeWeight(g.addEdge("a", "b"), 1. / 2);
+        g.setEdgeWeight(g.addEdge("a", "c"), 1. / 3);
+        g.setEdgeWeight(g.addEdge("b", "a"), 1);
+        g.setEdgeWeight(g.addEdge("b", "b"), 2);
+        g.setEdgeWeight(g.addEdge("b", "d"), 1. / 4);
+        g.setEdgeWeight(g.addEdge("c", "a"), 1);
+        g.setEdgeWeight(g.addEdge("c", "d"), 3);
+        g.setEdgeWeight(g.addEdge("d", "b"), 1. / 5);
+        g.setEdgeWeight(g.addEdge("d", "d"), 1);
 
-        final VertexScoringAlgorithm<String, Double> pr =
-				new EigenvectorCentrality<>(g);
+        final VertexScoringAlgorithm<String, Double> pr = new EigenvectorCentrality<>(g);
 
-		assertEquals(pr.getVertexScore("a"), 0.400610775759173, 0.0001);
-		assertEquals(pr.getVertexScore("b"), 0.863882834704165, 0.0001);
-		assertEquals(pr.getVertexScore("c"), 0.0580276877361552, 0.0001);
-		assertEquals(pr.getVertexScore("d"), 0.299750298600000, 0.0001);
+        assertEquals(pr.getVertexScore("a"), 0.400610775759173, 0.0001);
+        assertEquals(pr.getVertexScore("b"), 0.863882834704165, 0.0001);
+        assertEquals(pr.getVertexScore("c"), 0.0580276877361552, 0.0001);
+        assertEquals(pr.getVertexScore("d"), 0.299750298600000, 0.0001);
     }
-
-
 
     @Test(expected = IllegalArgumentException.class)
     public void testNonExistantVertex()
     {
-        final DirectedPseudograph<String, DefaultEdge> g = new DirectedPseudograph<>(DefaultEdge.class);
+        final DirectedPseudograph<String, DefaultEdge> g =
+            new DirectedPseudograph<>(DefaultEdge.class);
 
         g.addVertex("center");
         g.addVertex("a");
@@ -149,8 +149,7 @@ public class EigenvectorCentralityTest
         g.addEdge("center", "b");
         g.addEdge("center", "c");
 
-        final VertexScoringAlgorithm<String, Double> pr =
-				new EigenvectorCentrality<>(g);
+        final VertexScoringAlgorithm<String, Double> pr = new EigenvectorCentrality<>(g);
 
         pr.getVertexScore("unknown");
     }
@@ -158,17 +157,19 @@ public class EigenvectorCentralityTest
     @Test(expected = IllegalArgumentException.class)
     public void testBadParameters1()
     {
-        final DirectedPseudograph<String, DefaultEdge> g = new DirectedPseudograph<>(DefaultEdge.class);
+        final DirectedPseudograph<String, DefaultEdge> g =
+            new DirectedPseudograph<>(DefaultEdge.class);
 
-		new EigenvectorCentrality<>(g, -1);
+        new EigenvectorCentrality<>(g, -1);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testBadParameters2()
     {
-        final DirectedPseudograph<String, DefaultEdge> g = new DirectedPseudograph<>(DefaultEdge.class);
+        final DirectedPseudograph<String, DefaultEdge> g =
+            new DirectedPseudograph<>(DefaultEdge.class);
 
-		new EigenvectorCentrality<>(g, 1, 0);
+        new EigenvectorCentrality<>(g, 1, 0);
     }
 
 }

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/scoring/EigenvectorCentralityTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/scoring/EigenvectorCentralityTest.java
@@ -1,0 +1,174 @@
+/*
+ * (C) Copyright 2020, by Sebastiano Vigna.
+ *
+ * JGraphT : a free Java graph-theory library
+ *
+ * See the CONTRIBUTORS.md file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the
+ * GNU Lesser General Public License v2.1 or later
+ * which is available at
+ * http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR LGPL-2.1-or-later
+ */
+package org.jgrapht.alg.scoring;
+
+import static org.junit.Assert.assertEquals;
+
+import org.jgrapht.alg.interfaces.VertexScoringAlgorithm;
+import org.jgrapht.graph.DefaultEdge;
+import org.jgrapht.graph.DefaultWeightedEdge;
+import org.jgrapht.graph.DirectedPseudograph;
+import org.jgrapht.graph.DirectedWeightedPseudograph;
+import org.junit.Test;
+
+/**
+ * Unit tests for eigenvector centrality
+ *
+ * @author Sebastiano Vigna
+ */
+public class EigenvectorCentralityTest
+{
+    @Test
+    public void testGraph2Nodes()
+    {
+        final DirectedPseudograph<String, DefaultEdge> g = new DirectedPseudograph<>(DefaultEdge.class);
+
+        g.addVertex("1");
+        g.addVertex("2");
+        g.addEdge("1", "2");
+        g.addEdge("2", "1");
+
+		final VertexScoringAlgorithm<String, Double> pr = new EigenvectorCentrality<>(g);
+
+		assertEquals(pr.getVertexScore("1"), 1 / Math.sqrt(2), 0.0001);
+		assertEquals(pr.getVertexScore("2"), 1 / Math.sqrt(2), 0.0001);
+    }
+
+    @Test
+    public void testGraph3Nodes()
+    {
+        final DirectedPseudograph<String, DefaultEdge> g = new DirectedPseudograph<>(DefaultEdge.class);
+
+        g.addVertex("1");
+        g.addVertex("2");
+        g.addVertex("3");
+        g.addEdge("1", "2");
+        g.addEdge("2", "3");
+        g.addEdge("3", "1");
+
+		final VertexScoringAlgorithm<String, Double> pr = new EigenvectorCentrality<>(g);
+
+		assertEquals(pr.getVertexScore("1"), 1 / Math.sqrt(3), 0.0001);
+		assertEquals(pr.getVertexScore("2"), 1 / Math.sqrt(3), 0.0001);
+		assertEquals(pr.getVertexScore("3"), 1 / Math.sqrt(3), 0.0001);
+    }
+
+    @Test
+    public void testGraph1()
+    {
+        final DirectedPseudograph<String, DefaultEdge> g = new DirectedPseudograph<>(DefaultEdge.class);
+
+        g.addVertex("0");
+        g.addVertex("1");
+        g.addVertex("2");
+        g.addVertex("3");
+        g.addVertex("4");
+
+		g.addEdge("0", "1");
+		g.addEdge("0", "2");
+		g.addEdge("1", "3");
+		g.addEdge("1", "2");
+		g.addEdge("2", "1");
+		g.addEdge("2", "4");
+		g.addEdge("2", "3");
+		g.addEdge("3", "1");
+		g.addEdge("3", "2");
+		g.addEdge("3", "3");
+		g.addEdge("4", "2");
+		g.addEdge("4", "0");
+
+		final VertexScoringAlgorithm<String, Double> pr = new EigenvectorCentrality<>(g);
+
+		assertEquals(pr.getVertexScore("0"), 0.08032022089204849, 0.001);
+		assertEquals(pr.getVertexScore("1"), 0.48765632797141506, 0.001);
+		assertEquals(pr.getVertexScore("2"), 0.5453987490787013, 0.001);
+		assertEquals(pr.getVertexScore("3"), 0.6437087676602127, 0.001);
+		assertEquals(pr.getVertexScore("4"), 0.20956906939251885, 0.001);
+    }
+
+
+    @Test
+    public void testWeightedGraph1()
+    {
+        final DirectedWeightedPseudograph<String, DefaultWeightedEdge> g =
+            new DirectedWeightedPseudograph<>(DefaultWeightedEdge.class);
+
+        g.addVertex("a");
+        g.addVertex("b");
+        g.addVertex("c");
+		g.addVertex("d");
+
+		g.setEdgeWeight(g.addEdge("a", "b"), 1. / 2);
+		g.setEdgeWeight(g.addEdge("a", "c"), 1. / 3);
+		g.setEdgeWeight(g.addEdge("b", "a"), 1);
+		g.setEdgeWeight(g.addEdge("b", "b"), 2);
+		g.setEdgeWeight(g.addEdge("b", "d"), 1. / 4);
+		g.setEdgeWeight(g.addEdge("c", "a"), 1);
+		g.setEdgeWeight(g.addEdge("c", "d"), 3);
+		g.setEdgeWeight(g.addEdge("d", "b"), 1. / 5);
+		g.setEdgeWeight(g.addEdge("d", "d"), 1);
+
+        final VertexScoringAlgorithm<String, Double> pr =
+				new EigenvectorCentrality<>(g);
+
+		assertEquals(pr.getVertexScore("a"), 0.400610775759173, 0.0001);
+		assertEquals(pr.getVertexScore("b"), 0.863882834704165, 0.0001);
+		assertEquals(pr.getVertexScore("c"), 0.0580276877361552, 0.0001);
+		assertEquals(pr.getVertexScore("d"), 0.299750298600000, 0.0001);
+    }
+
+
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testNonExistantVertex()
+    {
+        final DirectedPseudograph<String, DefaultEdge> g = new DirectedPseudograph<>(DefaultEdge.class);
+
+        g.addVertex("center");
+        g.addVertex("a");
+        g.addVertex("b");
+        g.addVertex("c");
+        g.addVertex("d");
+
+        g.addEdge("center", "a");
+        g.addEdge("center", "b");
+        g.addEdge("center", "c");
+
+        final VertexScoringAlgorithm<String, Double> pr =
+				new EigenvectorCentrality<>(g);
+
+        pr.getVertexScore("unknown");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testBadParameters1()
+    {
+        final DirectedPseudograph<String, DefaultEdge> g = new DirectedPseudograph<>(DefaultEdge.class);
+
+		new EigenvectorCentrality<>(g, -1);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testBadParameters2()
+    {
+        final DirectedPseudograph<String, DefaultEdge> g = new DirectedPseudograph<>(DefaultEdge.class);
+
+		new EigenvectorCentrality<>(g, 1, 0);
+    }
+
+}


### PR DESCRIPTION
This pull request implements eigenvector centrality. As discussed in https://github.com/jgrapht/jgrapht/issues/1013, AlphaCentrality is not really computing eigenvector centrality. This class implements the power method with 𝓁₂ normalization (the most commonly used normalization).

I think that it would be a good idea to have a KatzCentrality class doing essentially what AlphaCentrality does, but pointing at the right papers and dispensing with the exogenous factor as a scalar. In Katz centrality, any constant vector will give the same centrality, just scaled by the constant contained in the vector. Having a scalar exogenous factor will make the user believe that by changing it the centrality computed will somehow change, but all that will happen is a rescaling. 

I refrained from touching the documentation in AlphaCentrality, but probably it would also be a good idea to eliminate the part related to eigenvector centrality, as it's not really computing it.